### PR TITLE
Fix component width

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,6 +16,6 @@
     <p>You have <vellum-dice>3d6+3</vellum-dice> Strength.</p>
 
     <h3>Roll with Animation</h3>
-    <p>You have <vellum-dice animation>3d6+3</vellum-dice> Strength.</p>
+    <p>You have <vellum-dice animation>2d6+3</vellum-dice> <u>Strength</u>.</p>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -9,6 +9,14 @@
         location.reload(),
       )
     </script>
+
+    <style>
+      vellum-dice.fixed-width {
+        display: inline-block;
+        width: 93px;
+        text-align: center;
+      }
+    </style>
   </head>
 
   <body>
@@ -16,6 +24,12 @@
     <p>You have <vellum-dice>3d6+3</vellum-dice> Strength.</p>
 
     <h3>Roll with Animation</h3>
-    <p>You have <vellum-dice animation>2d6+3</vellum-dice> <u>Strength</u>.</p>
+    <p>You have <vellum-dice animation>3d6+3</vellum-dice> Strength.</p>
+
+    <h3>Roll with fixed width</h3>
+    <p>
+      You have
+      <vellum-dice class="fixed-width" animation>3d6+3</vellum-dice> Strength.
+    </p>
   </body>
 </html>

--- a/src/dice.ts
+++ b/src/dice.ts
@@ -11,6 +11,7 @@ function rollDice(sides: number) {
 
 export abstract class Die {
   abstract roll(): Roll
+  abstract get max(): number
 
   static from(notation: string): Die {
     switch (notation) {
@@ -23,6 +24,10 @@ export abstract class Die {
 }
 
 const D66 = new (class extends Die {
+  override get max() {
+    return 66
+  }
+
   override roll(): Roll {
     const rolls = [rollDice(6), rollDice(6)]
     return {
@@ -48,6 +53,10 @@ class StandardDie extends Die {
     this.number = parseInt(number)
     this.sides = parseInt(sides)
     this.modifier = parseInt(plusMinus + modifier)
+  }
+
+  override get max(): number {
+    return this.number * this.sides + this.modifier
   }
 
   override roll(): Roll {

--- a/src/vellum-dice.ts
+++ b/src/vellum-dice.ts
@@ -17,8 +17,14 @@ export class VellumDice extends LitElement {
     :host {
       display: inline;
       cursor: pointer;
-      text-decoration: underline;
       font-weight: bold;
+
+      border-bottom: 1px solid black;
+    }
+
+    .result {
+      display: inline-block;
+      min-width: 2ch;
     }
   `
 
@@ -32,8 +38,8 @@ export class VellumDice extends LitElement {
 
   render() {
     return html`
-      <span @click="${this.reroll}">
-        ${this.die ? asyncReplace(rollAnimation(this.die, 4)) : ''} (<slot></slot>&#9860;)
+      <span class="roll" @click="${this.reroll}">
+        <span class="result">${this.die ? asyncReplace(rollAnimation(this.die, 4)) : ''}</span> (<slot></slot>&#9860;)
       </span>
     `
   }


### PR DESCRIPTION
The component width can shift depending on the width of the numerical result (e.g. single digit or double-digit results, etc.). This can cause other elements to move around, changing the layout unexpectedly and leading to a bad user experience.

This change fixes the width of the element to prevent this.

https://github.com/grislyeye/vellum-dice/assets/37806009/5cc745d2-b4b1-40b3-bdcb-eb6f7306dea5

