### PR TITLE
Add: success and failure events

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Web component and interactive dice roller. Inspired by [javalent/dice-roller](ht
 | Attribute   | Description                               | Default |
 | ----------- | ----------------------------------------- | ------- |
 | `animation` | Juice the roll with a flash of pre-rolls. | `false` |
+| `min`       | Defines the success range as `>= min`. | _Optional_ |
 
 ### Examples
 
@@ -29,7 +30,7 @@ Include the `<script>` in your markup:
 ```html
 <script
   type="module"
-  src="https://www.unpkg.com/vellum-dice@0.1.0/vellum-dice.js"
+  src="https://www.unpkg.com/vellum-dice@0.2.0/vellum-dice.js"
 ></script>
 <p>You have <vellum-dice> 3d6+3 </vellum-dice> Strength.</p>
 ```

--- a/index.html
+++ b/index.html
@@ -31,5 +31,11 @@
       You have
       <vellum-dice class="fixed-width" animation>3d6+3</vellum-dice> Strength.
     </p>
+
+    <h3>Roll with success/failure</h3>
+    <p>
+      You have
+      <vellum-dice min="7">3d6+3</vellum-dice> Strength.
+    </p>
   </body>
 </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vellum-dice",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vellum-dice",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "lit": "^3.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vellum-dice",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Web component and interactive dice roller. ",
   "author": "Ric Wood <ric@grislyeye.com>",
   "repository": "https://github.com/grislyeye/vellum-dice",

--- a/src/vellum-dice.ts
+++ b/src/vellum-dice.ts
@@ -25,6 +25,9 @@ export class VellumDice extends LitElement {
   @property({ type: Boolean })
   animation: boolean = false
 
+  @property({ type: Number })
+  min: number | undefined
+
   get die(): Die | undefined {
     return this.textContent ? Die.from(this.textContent.trim()) : undefined
   }
@@ -43,9 +46,11 @@ export class VellumDice extends LitElement {
   }
 
   render() {
+    const roll = this.roll()
+
     return html`
-      <span @click="${this.reroll}">
-        ${this.roll()} (<slot></slot>&#9860;)
+      <span @click="${this.reroll}" class="${this.min && roll >= this.min ? 'success' : 'faulure'}">
+        ${roll} (<slot></slot>&#9860;)
       </span>
     `
   }


### PR DESCRIPTION
Fire events on a success or failure. Success is determined by `min` or `max` attributes:

```html
<vellum-dice min="7">3d6+3</vellum-dice>
```

Success or failure changes the colour of the component text. Defaults are green for success, red for failure. We will create `--success-color` and `--failure-color` CSS variables to customise these defaults.

On a successful roll, the component emits a `success` event. Conversely, failed rolls emit `failure` events. This can be scripted as follows:

```js
const dice = document.querySelector('vellum-dice')

function success(event) {
  alerts(`success on ${event.detail.result}`
}

dice.addEventListener('success', success)
```

Notes:

- What should be the behaviour if both `min` and `max` attributes are set?
- Should we support handling other kinds of success (i.e. rolling doubles)?